### PR TITLE
Hyphen in domain name

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-charms_summer_school.com
+charms-summer-school.com


### PR DESCRIPTION
Underscores are not allowed in domain names, but hyphens should work.